### PR TITLE
BUGFIX: do not display JD(UT) instead of JD(TT)

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
                 <div class="explanation" id="jd_tt-explanation">
                     <div class="clock">
                         <h3>Julian Date (TT)</h3>
-                        <span class="time jd_ut"></span>
+                        <span class="time jd_tt"></span>
                     </div>
                     <p>
                         We actually need the Terrestrial Time (TT) Julian Date rather than the UTC-based one.


### PR DESCRIPTION
Fixing a trivial bug:

Mousing over JD(TT) on the left column would display on the right the
proper description but the wrong time.